### PR TITLE
Fixes `httpcore` import in `httpx_ws/_api.py`

### DIFF
--- a/httpx_ws/_api.py
+++ b/httpx_ws/_api.py
@@ -11,7 +11,7 @@ import typing
 import httpcore
 import httpx
 import wsproto
-from httpcore._backends.base import AsyncNetworkStream, NetworkStream
+from httpcore import AsyncNetworkStream, NetworkStream
 from wsproto.connection import CloseReason
 
 from httpx_ws._ping import AsyncPingManager, PingManager

--- a/httpx_ws/_api.py
+++ b/httpx_ws/_api.py
@@ -11,7 +11,7 @@ import typing
 import httpcore
 import httpx
 import wsproto
-from httpcore.backends.base import AsyncNetworkStream, NetworkStream
+from httpcore._backends.base import AsyncNetworkStream, NetworkStream
 from wsproto.connection import CloseReason
 
 from httpx_ws._ping import AsyncPingManager, PingManager

--- a/httpx_ws/transport.py
+++ b/httpx_ws/transport.py
@@ -5,7 +5,7 @@ from concurrent.futures import Future
 
 import anyio
 import wsproto
-from httpcore.backends.base import AsyncNetworkStream
+from httpcore import AsyncNetworkStream, NetworkStream
 from httpx import ASGITransport, AsyncByteStream, Request, Response
 from wsproto.connection import CloseReason
 

--- a/httpx_ws/transport.py
+++ b/httpx_ws/transport.py
@@ -5,7 +5,7 @@ from concurrent.futures import Future
 
 import anyio
 import wsproto
-from httpcore import AsyncNetworkStream, NetworkStream
+from httpcore import AsyncNetworkStream
 from httpx import ASGITransport, AsyncByteStream, Request, Response
 from wsproto.connection import CloseReason
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires-python = ">=3.8"
 dependencies = [
     "anyio",
     "httpx>=0.23.1",
-    "httpcore>=0.16.1",
+    "httpcore>=0.17.3,<0.18",
     "wsproto",
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import httpcore
 import httpx
 import pytest
 import wsproto
-from httpcore.backends.base import AsyncNetworkStream, NetworkStream
+from httpcore import AsyncNetworkStream, NetworkStream
 from starlette.websockets import WebSocket
 from starlette.websockets import WebSocketDisconnect as StarletteWebSocketDisconnect
 


### PR DESCRIPTION
Fixes #35 