### PR TITLE
Improve _wait_until_closed()

### DIFF
--- a/httpx_ws/_api.py
+++ b/httpx_ws/_api.py
@@ -5,7 +5,6 @@ import json
 import queue
 import secrets
 import threading
-import time
 import typing
 from types import TracebackType
 
@@ -83,11 +82,24 @@ class WebSocketSession:
 
         self._ping_manager = PingManager()
         self._should_close = threading.Event()
+        self._should_close_task: typing.Optional[concurrent.futures.Future[bool]] = None
+        self._executor: typing.Optional[concurrent.futures.ThreadPoolExecutor] = None
 
         self._max_message_size_bytes = max_message_size_bytes
         self._queue_size = queue_size
         self._keepalive_ping_interval_seconds = keepalive_ping_interval_seconds
         self._keepalive_ping_timeout_seconds = keepalive_ping_timeout_seconds
+
+    def _get_executor_should_close_task(
+        self,
+    ) -> typing.Tuple[
+        concurrent.futures.ThreadPoolExecutor, concurrent.futures.Future[bool]
+    ]:
+        if self._should_close_task is None:
+            self._executor = concurrent.futures.ThreadPoolExecutor()
+            self._should_close_task = self._executor.submit(self._should_close.wait)
+        assert self._executor is not None
+        return self._executor, self._should_close_task
 
     def __enter__(self) -> "WebSocketSession":
         self._background_receive_task = threading.Thread(
@@ -427,6 +439,8 @@ class WebSocketSession:
                 ws.close()
         """
         self._should_close.set()
+        if self._executor is not None:
+            self._executor.shutdown(False)
         if self.connection.state not in {
             wsproto.connection.ConnectionState.LOCAL_CLOSING,
             wsproto.connection.ConnectionState.CLOSED,
@@ -518,32 +532,20 @@ class WebSocketSession:
     def _wait_until_closed(
         self, callable: typing.Callable[..., TaskResult], *args, **kwargs
     ) -> TaskResult:
-        exit_await = threading.Event()
-
-        def wait_close() -> None:
-            while not exit_await.is_set() and not self._should_close.is_set():
-                time.sleep(0.05)
-
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
         try:
-            wait_close_task = executor.submit(wait_close)
+            executor, should_close_task = self._get_executor_should_close_task()
             todo_task = executor.submit(callable, *args, **kwargs)
         except RuntimeError as e:
             raise ShouldClose() from e
         else:
             done, _ = concurrent.futures.wait(
-                (todo_task, wait_close_task),  # type: ignore[misc]
+                (todo_task, should_close_task),  # type: ignore[misc]
                 return_when=concurrent.futures.FIRST_COMPLETED,
             )
-            if wait_close_task in done:
+            if should_close_task in done:
                 raise ShouldClose()
             assert todo_task in done
-            if not wait_close_task.cancel():
-                exit_await.set()
-                wait_close_task.result()
             result = todo_task.result()
-        finally:
-            executor.shutdown(False)
         return result
 
 

--- a/httpx_ws/_api.py
+++ b/httpx_ws/_api.py
@@ -93,7 +93,7 @@ class WebSocketSession:
     def _get_executor_should_close_task(
         self,
     ) -> typing.Tuple[
-        concurrent.futures.ThreadPoolExecutor, concurrent.futures.Future[bool]
+        concurrent.futures.ThreadPoolExecutor, "concurrent.futures.Future[bool]"
     ]:
         if self._should_close_task is None:
             self._executor = concurrent.futures.ThreadPoolExecutor()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -928,6 +928,9 @@ async def test_threads_wont_hang(server_factory: ServerFactoryFixture) -> None:
                 for _ in range(50):
                     ws.receive()
                     ws.send_text("CLIENT_MESSAGE")
-                time.sleep(0.5)  # Let the websocket endpoint finish its handling.
-                final_threads_count = threading.active_count()
-                assert initial_threads_count == final_threads_count
+                time.sleep(0.1)  # Let the websocket endpoint finish its handling.
+                threads_count = threading.active_count()
+                assert initial_threads_count + 2 == threads_count
+            time.sleep(0.1)
+            final_threads_count = threading.active_count()
+            assert initial_threads_count == final_threads_count


### PR DESCRIPTION
This PR gets rid of the polling here:
https://github.com/frankie567/httpx-ws/blob/3b2776b5bea0010685791cc383ca7d0af9762e1e/httpx_ws/_api.py#L523-L525
But still fixes #76, by having just one thread waiting for the `self._should_close` event. The thread is created once and reused afterwards.
Strangely this reveals some flakiness, e.g. in `tests/test_api.py::TestReceive::test_receive_oversized_message`, that is less frequent before this PR.