### PR TITLE
Add cancel scope integrity test for `ASGIWebSocketTransport`

### DIFF
--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 import pytest
 import wsproto
+from anyio import CancelScope
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route, WebSocketRoute
@@ -245,3 +246,22 @@ async def test_keepalive_ping_disabled():
     async with httpx.AsyncClient(transport=ASGIWebSocketTransport(app)) as client:
         async with aconnect_ws("ws://localhost:8000/ws", client) as ws:
             assert ws._keepalive_ping_interval_seconds is None
+
+
+@pytest.mark.anyio
+async def test_cancel_scope_integrity():
+    async def websocket_endpoint(websocket: WebSocket):
+        await websocket.accept()
+        await websocket.receive_text()
+        await websocket.close()
+
+    app = Starlette(
+        routes=[
+            WebSocketRoute("/ws", endpoint=websocket_endpoint),
+        ]
+    )
+
+    async with httpx.AsyncClient(transport=ASGIWebSocketTransport(app)) as client:
+        with CancelScope():
+            async with aconnect_ws("ws://localhost:8000/ws", client):
+                pass


### PR DESCRIPTION
This test fails on `main` and passes in #108.