### PR TITLE
Fix hanging on asyncio when exiting context manager post-cancellation

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,7 +95,7 @@ class TestSend:
                 self._should_close = True
 
         stream = AsyncMockNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.send(wsproto.events.Ping())
 
@@ -275,7 +275,7 @@ class TestReceive:
                 pass
 
         stream = AsyncMockNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.receive()
 
@@ -296,7 +296,7 @@ class TestReceive:
                 pass
 
         stream = AsyncMockNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.receive()
 
@@ -686,7 +686,7 @@ class TestKeepalivePing:
                 self._should_close = True
 
         stream = MockAsyncNetworkStream()
-        with pytest.raises(WebSocketNetworkError):
+        with pytest.RaisesGroup(WebSocketNetworkError):
             async with AsyncWebSocketSession(
                 stream,
                 keepalive_ping_interval_seconds=0.1,


### PR DESCRIPTION
I have been running into the same bug as #107. It can be reproduced with the following simple code:

```python
import anyio
from httpx_ws import aconnect_ws

async def stream():
    async with aconnect_ws("wss://echo.websocket.org"):
        await anyio.sleep(1e9)

async def main():
    async with anyio.create_task_group() as tg:
        tg.start_soon(stream)
        await anyio.sleep(1)
        tg.cancel_scope.cancel()

anyio.run(main)
```

While I was unable to understand *exactly* what the cause was, it was clear that `AsyncWebSocketSession.__aexit__` has some very weird behavior related to the `AsyncExitStack`. To solve this, I simply implemented anyio's `AsyncContextManagerMixin`, which is the standard way to avoid these kinds of nasty bugs. The exit stack was removed and all initialization and cleanup code happens in `__asynccontextmanager__`.

As a consequence of this, several tests were slightly tweaked since some kinds of errors will be raised in an `ExceptionGroup`.
