### PR TITLE
Unwrap WebSocketNetworkError exception group

### DIFF
--- a/httpx_ws/_api.py
+++ b/httpx_ws/_api.py
@@ -8,6 +8,7 @@ import threading
 import typing
 
 import anyio
+import exceptiongroup
 import httpcore
 import httpx
 import wsproto
@@ -623,23 +624,37 @@ class AsyncWebSocketSession(anyio.AsyncContextManagerMixin):
         ]()
         self._background_task_group = anyio.create_task_group()
 
-        async with self._send_event, self._receive_event, self._background_task_group:
-            self._background_task_group.start_soon(
-                self._background_receive, self._max_message_size_bytes
-            )
-            if self._keepalive_ping_interval_seconds is not None:
-                self._background_task_group.start_soon(
-                    self._background_keepalive_ping,
-                    self._keepalive_ping_interval_seconds,
-                    self._keepalive_ping_timeout_seconds,
-                )
+        def unwrap_network_error(
+            exc: exceptiongroup.BaseExceptionGroup,
+        ) -> typing.NoReturn:
+            raise exc.exceptions[0]
 
-            try:
-                yield self
-            finally:
-                self._background_task_group.cancel_scope.cancel()
-                with anyio.CancelScope(shield=True):
-                    await self.close()
+        with exceptiongroup.catch(
+            {
+                WebSocketNetworkError: unwrap_network_error,
+            }
+        ):
+            async with (
+                self._send_event,
+                self._receive_event,
+                self._background_task_group,
+            ):
+                self._background_task_group.start_soon(
+                    self._background_receive, self._max_message_size_bytes
+                )
+                if self._keepalive_ping_interval_seconds is not None:
+                    self._background_task_group.start_soon(
+                        self._background_keepalive_ping,
+                        self._keepalive_ping_interval_seconds,
+                        self._keepalive_ping_timeout_seconds,
+                    )
+
+                try:
+                    yield self
+                finally:
+                    self._background_task_group.cancel_scope.cancel()
+                    with anyio.CancelScope(shield=True):
+                        await self.close()
 
     async def ping(self, payload: bytes = b"") -> anyio.Event:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "httpx>=0.23.1",
     "httpcore>=1.0.4",
     "wsproto",
+    "exceptiongroup>=1.3.0",
 ]
 
 [project.urls]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,7 +95,7 @@ class TestSend:
                 self._should_close = True
 
         stream = AsyncMockNetworkStream()
-        with pytest.RaisesGroup(WebSocketNetworkError):
+        with pytest.raises(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.send(wsproto.events.Ping())
 
@@ -275,7 +275,7 @@ class TestReceive:
                 pass
 
         stream = AsyncMockNetworkStream()
-        with pytest.RaisesGroup(WebSocketNetworkError):
+        with pytest.raises(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.receive()
 
@@ -296,7 +296,7 @@ class TestReceive:
                 pass
 
         stream = AsyncMockNetworkStream()
-        with pytest.RaisesGroup(WebSocketNetworkError):
+        with pytest.raises(WebSocketNetworkError):
             async with AsyncWebSocketSession(stream) as websocket_session:
                 await websocket_session.receive()
 
@@ -684,7 +684,7 @@ class TestKeepalivePing:
                 self._should_close = True
 
         stream = MockAsyncNetworkStream()
-        with pytest.RaisesGroup(WebSocketNetworkError):
+        with pytest.raises(WebSocketNetworkError):
             async with AsyncWebSocketSession(
                 stream,
                 keepalive_ping_interval_seconds=0.1,

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "anyio"
@@ -421,6 +425,7 @@ name = "httpx-ws"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
+    { name = "exceptiongroup" },
     { name = "httpcore" },
     { name = "httpx" },
     { name = "wsproto" },
@@ -442,6 +447,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4" },
+    { name = "exceptiongroup", specifier = ">=1.3.0" },
     { name = "httpcore", specifier = ">=1.0.4" },
     { name = "httpx", specifier = ">=0.23.1" },
     { name = "wsproto" },


### PR DESCRIPTION

Considering the potential breaking change and inconsistency with the sync implementation introduced by #129, I'm considering to implicitly unwrap the exception group to re-raise the WebSocketNetworkError solo.
