### PR TITLE
Bump anyio dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "anyio>=4",
+    "anyio>=4.10.0", # AsyncContextManagerMixin added in https://github.com/agronholm/anyio/commit/6977fc37.
     "httpx>=0.23.1",
     "httpcore>=1.0.4",
     "wsproto",


### PR DESCRIPTION
38219f35 introduced a reference to `anyio.AsyncContextManagerMixin` which was added in https://github.com/agronholm/anyio/commit/6977fc37 and released in anyio 4.10.0.