### PR TITLE
Return EOF when ASGI stream closes

### DIFF
--- a/httpx_ws/transport.py
+++ b/httpx_ws/transport.py
@@ -107,7 +107,13 @@ class ASGIWebSocketAsyncNetworkStream(AsyncNetworkStream):
         return await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
 
     async def read(self, max_bytes: int, timeout: float | None = None) -> bytes:
-        message: Message = await self.receive(timeout=timeout)
+        try:
+            message: Message = await self.receive(timeout=timeout)
+        except anyio.EndOfStream:
+            # HTTP Core maps AnyIO's closed-stream signal to b"" at the
+            # AsyncNetworkStream boundary:
+            # https://github.com/encode/httpcore/blob/10a658221deb38a4c5b16db55ab554b0bf731707/httpcore/_backends/anyio.py#L25-L37
+            return b""
         type = message["type"]
 
         if type not in {"websocket.send", "websocket.close"}:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -13,7 +13,12 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket
 
-from httpx_ws import WebSocketDisconnect, WebSocketUpgradeError, aconnect_ws
+from httpx_ws import (
+    AsyncWebSocketSession,
+    WebSocketDisconnect,
+    WebSocketUpgradeError,
+    aconnect_ws,
+)
 from httpx_ws.transport import (
     ASGIWebSocketAsyncNetworkStream,
     ASGIWebSocketTransport,
@@ -360,6 +365,33 @@ async def test_cancel_scope_integrity():
         with CancelScope():
             async with aconnect_ws("ws://localhost:8000/ws", client):
                 pass
+
+
+@pytest.mark.anyio
+async def test_close_session_from_another_task():
+    async def app(scope, receive, send):
+        await receive()
+        await send({"type": "websocket.accept"})
+        await receive()
+
+    exit_requested = anyio.Event()
+
+    async with httpx.AsyncClient(
+        transport=ASGIWebSocketTransport(app), base_url="http://test"
+    ) as client:
+
+        async def connection(
+            *, task_status: anyio.abc.TaskStatus[AsyncWebSocketSession]
+        ) -> None:
+            async with aconnect_ws("/ws", client) as websocket:
+                task_status.started(websocket)
+                await exit_requested.wait()
+
+        async with create_task_group() as task_group:
+            websocket = await task_group.start(connection)
+            await websocket.close()
+            await anyio.sleep(0)
+            exit_requested.set()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
`ASGIWebSocketTransport` closes its AnyIO memory streams during
shutdown. AnyIO reports closure of the sending side by raising
`EndOfStream` from a pending receive. `ASGIWebSocketAsyncNetworkStream`
currently leaks that backend-specific exception from
`AsyncNetworkStream.read()`, so a session context owned by another task
exits with an `ExceptionGroup` during normal cleanup.

Map AnyIO's closure signal to `b""`, matching HTTP Core's AnyIO stream
adapter and the session's existing EOF handling. Add a regression for
explicit session close while another task owns the connection context.

Fixes #146.
